### PR TITLE
Minor/doc updates

### DIFF
--- a/src/fpds/core/parser.py
+++ b/src/fpds/core/parser.py
@@ -2,7 +2,7 @@
 Base classes for FPDS XML elements
 
 author: derek663@gmail.com
-last_updated: 01/02/2023
+last_updated: 05/01/2023
 """
 
 import re


### PR DESCRIPTION
Adding missing docstrings for seemingly clear functions. Adding appropriate return types and clarifying the definition of what an `entry` is.