### PR TITLE
Fixing the CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 keywords = ["fpds", "python", "atom feed", "cli", "xml"]
-version = "1.3.0"
+version = "1.3.1"
 classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",

--- a/src/fpds/cli/parse.py
+++ b/src/fpds/cli/parse.py
@@ -65,7 +65,7 @@ def parse(params, output):
 
     request = fpdsRequest(**params_kwargs, cli_run=True)
     click.echo("Retrieving FPDS records from ATOM feed...")
-    records = request()
+    records = request.process_records()
 
     DATA_DIR = OUTPUT_PATH if output else FPDS_DATA_DATE_DIR
     DATA_FILE = DATA_DIR / f"{uuid4()}.json"


### PR DESCRIPTION
When running `fpds parse` in the CLI, I got the following error:

> TypeError: 'fpdsRequest' object is not callable

This PR removes `request()` call and adds the `process_records()` call to the fpdsRequest.