### PR TITLE
[MINOR] Support unbounded range regex patterns for range based variables and escape characters properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ $ make local-test
 ```
 
 ## What's New
-As of 08/21/2024, `v1.4.0` data is returned as a generator, providing more flexibility
+As of 08/21/2024, `v1.4.1` data is returned as a generator, providing more flexibility
 for memory constrained devices. Users also have the ability to select specific
 pages of results with the `page` parameter.
+
+Parameters in `fields.json` have been updated to support unbounded values. Previously, range-based parameters had to define an upper & lower bound (i.e. `[4250, 7500]`). In the most current version of this library, you can now specify the following patterns for all range parameters: `[4250,)` or `(, 7500]`. This even works for dates: `[2022/08/22,)` or `(, 2022/08/01]`!
 
 `fpds` now supports asynchronous requests! As of `v1.3.0`, users can instantiate
 the class as usual, but will now need to call the `process_records` method

--- a/README.md
+++ b/README.md
@@ -51,13 +51,17 @@ $  fpds parse "LAST_MOD_DATE=[2022/01/01, 2022/05/01]" "AGENCY_CODE=7504" -o my-
 Same request via python interpreter:
 ```
 import asyncio
+from itertools import chain
 from fpds import fpdsRequest
 
 request = fpdsRequest(
     LAST_MOD_DATE="[2022/01/01, 2022/05/01]",
     AGENCY_CODE="7504"
 )
-data = list(asyncio.run(request.data()))
+
+# results are nested lists so de-nest
+data = asyncio.run(request.data())
+records = list(chain.from_iterable(data))
 ```
 
 For linting and formatting, we use `flake8` and `black`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.8"
 keywords = ["fpds", "python", "atom feed", "cli", "xml"]
-version = "1.4.0"
+version = "1.4.1"
 classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",

--- a/src/fpds/cli/parse.py
+++ b/src/fpds/cli/parse.py
@@ -6,7 +6,9 @@ author: derek663@gmail.com
 last_updated: 12/30/2022
 """
 
+import asyncio
 import json
+from itertools import chain
 from pathlib import Path
 from uuid import uuid4
 
@@ -65,7 +67,9 @@ def parse(params, output):
 
     request = fpdsRequest(**params_kwargs, cli_run=True)
     click.echo("Retrieving FPDS records from ATOM feed...")
-    records = request()
+
+    data = asyncio.run(request.data())
+    records = list(chain.from_iterable(data))
 
     DATA_DIR = OUTPUT_PATH if output else FPDS_DATA_DATE_DIR
     DATA_FILE = DATA_DIR / f"{uuid4()}.json"

--- a/src/fpds/constants/fields.json
+++ b/src/fpds/constants/fields.json
@@ -94,6 +94,7 @@
         "name": "CLOSED_DATE",
         "quotes": false,
         "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+    },
     {
         "description": "Closed Status",
         "name": "CLOSED_STATUS",

--- a/src/fpds/constants/fields.json
+++ b/src/fpds/constants/fields.json
@@ -69,7 +69,7 @@
         "description": "Base and Exercised Options Value",
         "name": "BASE_EXERCISED_OPTIONS_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Cage Code",
@@ -165,7 +165,7 @@
         "description": "Current Contract Value",
         "name": "CURRENT_CONTRACT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Department ID",
@@ -339,13 +339,13 @@
         "description": "Number of Offers Received",
         "name": "NUMBER_OF_OFFERS_RECEIVED",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Action Obligation",
         "name": "OBLIGATED_AMOUNT",
         "quotes": true,
-        "regex": "\\[\\d+, \\d+\\]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Contract ID",
@@ -476,25 +476,25 @@
         "description": "Total Base And All Options Value ($)",
         "name": "TOTAL_CURRENT_CONTRACT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Total Dollars Obligated",
         "name": "TOTAL_DOLLARS_OBLIGATED",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Total Non Government Value",
         "name": "TOTAL_NON_GOVERNMENT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Total Base and Exercised Options Value ($)",
         "name": "TOTAL_ULTIMATE_CONTRACT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+]"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
     },
     {
         "description": "Treasury Account Symbol",

--- a/src/fpds/constants/fields.json
+++ b/src/fpds/constants/fields.json
@@ -69,7 +69,7 @@
         "description": "Base and Exercised Options Value",
         "name": "BASE_EXERCISED_OPTIONS_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Cage Code",
@@ -165,7 +165,7 @@
         "description": "Current Contract Value",
         "name": "CURRENT_CONTRACT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Department ID",
@@ -339,13 +339,13 @@
         "description": "Number of Offers Received",
         "name": "NUMBER_OF_OFFERS_RECEIVED",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Action Obligation",
         "name": "OBLIGATED_AMOUNT",
         "quotes": true,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Contract ID",
@@ -476,25 +476,25 @@
         "description": "Total Base And All Options Value ($)",
         "name": "TOTAL_CURRENT_CONTRACT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Total Dollars Obligated",
         "name": "TOTAL_DOLLARS_OBLIGATED",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Total Non Government Value",
         "name": "TOTAL_NON_GOVERNMENT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Total Base and Exercised Options Value ($)",
         "name": "TOTAL_ULTIMATE_CONTRACT_VALUE",
         "quotes": false,
-        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)"
+        "regex": "\\[\\d+, \\d+\\]|\\[\\d+,\\)|\\(,\\d+\\]"
     },
     {
         "description": "Treasury Account Symbol",

--- a/src/fpds/constants/fields.json
+++ b/src/fpds/constants/fields.json
@@ -45,13 +45,13 @@
         "description": "Approved Date",
         "name": "APPROVED_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     },
     {
         "description": "Award Completion Date",
         "name": "AWARD_COMPLETION_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     },
     {
         "description": "Award Status (Deleted | Final)",
@@ -93,8 +93,7 @@
         "description": "Closed Date",
         "name": "CLOSED_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
-    },
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     {
         "description": "Closed Status",
         "name": "CLOSED_STATUS",
@@ -159,7 +158,7 @@
         "description": "Created Date",
         "name": "CREATED_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     },
     {
         "description": "Current Contract Value",
@@ -189,13 +188,13 @@
         "description": "Period of Performance Start Date",
         "name": "EFFECTIVE_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     },
     {
         "description": "Estimated Completion Date",
         "name": "ESTIMATED_COMPLETION_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     },
     {
         "description": "Evaluated Preference",
@@ -285,7 +284,7 @@
         "description": "Last Modified Date",
         "name": "LAST_MOD_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     },
     {
         "description": "Legislative Mandates",
@@ -434,7 +433,7 @@
         "description": "Date Signed",
         "name": "SIGNED_DATE",
         "quotes": false,
-        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]"
+        "regex": "\\[\\d{4}\\/\\d{2}\\/\\d{2}\\s*,\\s*\\d{4}\\/\\d{2}\\/\\d{2}\\]|\\[\\d{4}\\/\\d{2}\\/\\d{2},\\)|\\(,\\d{4}\\/\\d{2}\\/\\d{2}\\]"
     },
     {
         "description": "Socio Economic Indicators",


### PR DESCRIPTION
Per user callout, support unbounded parameter values. For range-based variables, you currently have to use an _extremely_ large value to capture data in an entire range set. For example:

`OBLIGATED_AMOUNT: [4250, 100000000000]`

With this PR, all range-based parameters support the additional syntax:
`[4250, )` or `(, 7000]`

Regex validation will capture any errors to ensure requests are properly sent.


This PR also escapes brackets in `constants/fields.json` in addition to using `asyncio` to de-nest records within the CLI command