### PR TITLE
minor: fix publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         uses: anothrNick/github-tag-action@v1
         id: cut-version
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           MAJOR_STRING_TOKEN: "^major:"
           MINOR_STRING_TOKEN: "^minor:"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,15 +23,15 @@ jobs:
       - name: Cut Version
         uses: anothrNick/github-tag-action@v1
         id: cut-version
-        with:
-          with-v: true
-          major-string-token: "^major:"
-          minor-string-token: "^minor:"
-          patch-string-token: "^patch:"
-          default-bump: patch
-          default-branch: master
-          branch-history: compare
-          match-path: .
+        env:
+          WITH_V: true
+          MAJOR_STRING_TOKEN: "^major:"
+          MINOR_STRING_TOKEN: "^minor:"
+          PATCH_STRING_TOKEN: "^patch:"
+          DEFAULT_BUMP: patch
+          DEFAULT_BRANCH: master
+          BRANCH_HISTORY: compare
+          MATCH_PATH: .
 
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Erroneously tried to pass parameters for cut-version as parameters rather than environment variables; total botch on my part. Semantically using `minor:` to ensure package is bumped properly going forward.