### PR TITLE
minor: add workflow_dispatch to trigger publish manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
       - src/**
       - pyproject.toml
       - uv.lock
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Due to some testing and errors with GHA, adding a workflow_dispatch trigger to allow me to trigger without changing the actual pypi package.