### PR TITLE
minor: update gh command in publish.yml to use create instead of edit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release edit "${{ steps.cut-version.outputs.new_tag }}" --draft=false
+        run: gh release create "${{ steps.cut-version.outputs.new_tag }}" --generate-notes --latest=true
 
   build-and-test:
     needs: [cut-release]


### PR DESCRIPTION
Erroneously used the `release edit` command instead of the `release create` command which caused failures due to the release not existing. With the updated regex commands, the semantic version is being identified properly; we just need to be able to publish a release so we can then publish the proper version to pypi.