### PR TITLE
patch: lower the default download concurrency

### DIFF
--- a/src/fpds/core/parser.py
+++ b/src/fpds/core/parser.py
@@ -53,7 +53,7 @@ class fpdsRequest(fpdsMixin):
         Defaults to `False`.
         If `True`, opts out of regex validation.
     thread_count: `int`
-        Defaults to 10.
+        Defaults to 4, please be considerate and avoid overwhelming the server (especially in peak early night hours in the US).
         The number of threads to send per search.
     page: `Optional[int]`
         Defaults to `None`.
@@ -83,7 +83,7 @@ class fpdsRequest(fpdsMixin):
         self,
         cli_run: bool = False,
         skip_regex_validation: bool = False,
-        thread_count: int = 10,
+        thread_count: int = 4,
         page: Optional[int] = None,
         **kwargs: str,
     ) -> None:


### PR DESCRIPTION
Lower the default download concurrency, because the FPDS source has been unstable in the last few months, especially during peak times.

The root cause might be a complex one (incl. problems on the source side), but we better have sensible defaults, which do NOT stress out the source server too much.